### PR TITLE
Revert add support for StoryBook addon-viewport

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,6 @@ module.exports = {
   stories: ['../stories/**/*.stories.tsx'],
   addons: [
     '@storybook/addon-actions/register',
-    '@storybook/addon-knobs/register',
-    '@storybook/addon-viewport/register'
+    '@storybook/addon-knobs/register'
   ]
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,14 +1,8 @@
 // require('loki/configure-react')
 const { addParameters } = require('@storybook/react')
 const { create } = require('@storybook/theming/create')
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 
 addParameters({
-  viewport: {
-    viewports: {
-      ...INITIAL_VIEWPORTS,
-    },
-  },
   options: {
     theme: create({
       base: 'light',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4502,33 +4502,6 @@
         }
       }
     },
-    "@storybook/addon-viewport": {
-      "version": "5.3.19",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-5.3.19.tgz",
-      "integrity": "sha512-/+9pN9yR/Dnwj/JEOwfnmERxDvh9alaFg7snnbiHSuycbPc+xy3CziqGUE9ofRxrYqOrd4aHhJ/5sxkZvewlAg==",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "5.3.19",
-        "@storybook/api": "5.3.19",
-        "@storybook/client-logger": "5.3.19",
-        "@storybook/components": "5.3.19",
-        "@storybook/core-events": "5.3.19",
-        "@storybook/theming": "5.3.19",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "memoizerific": "^1.11.3",
-        "prop-types": "^15.7.2",
-        "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "dev": true
-        }
-      }
-    },
     "@storybook/addons": {
       "version": "5.3.19",
       "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.19.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@storybook/addon-info": "^5.3.19",
     "@storybook/addon-knobs": "^5.3.19",
     "@storybook/addon-links": "^5.3.19",
-    "@storybook/addon-viewport": "^5.3.19",
     "@storybook/addons": "^5.3.19",
     "@storybook/preset-typescript": "^3.0.0",
     "@storybook/react": "^5.3.19",

--- a/src/TODO
+++ b/src/TODO
@@ -1,4 +1,4 @@
-[ ] Add responsibe graphic ad storybook plugin
+[ ] Add responsibe graphic
 [ ] Add tests UI
 [ ] Add end to end testing
 [ ] Add loki visual regression


### PR DESCRIPTION
Revert add support for StoryBook addon-viewport because it creates React warnings StoryBook.